### PR TITLE
Modify blob detection to 3d

### DIFF
--- a/skimage/feature/blob3d.py
+++ b/skimage/feature/blob3d.py
@@ -240,7 +240,7 @@ def blob_log3(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     image_cube = np.dstack(gl_images)
 
     local_maxima = peak_local_max(image_cube, threshold_abs=threshold,
-                                  min_distance=3),
+                                  min_distance=3,
                                   threshold_rel=0.0,
                                   exclude_border=False)
 
@@ -252,7 +252,7 @@ def blob_log3(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     # Convert the last index to its corresponding scale value
     lm[:, 3] = sigma_list[local_maxima[:, 3]]
     local_maxima = lm
-    return local_maxima
+    return _prune_blobs(local_maxima, overlap)
 
 #not supported until i can figure out how to do the slices in 3d space
 #def blob_doh3(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,


### PR DESCRIPTION
creates new functions for 3d blob detection using DoG and LoG (but not hessian DoH)
I thought I was saving this locally to my own repo so if you see this, hi, sorry about that.

## Description
work in progress, new functions for detection of spheres in 3d images
the only large change was to the measurement of overlapping volumes of spheres
other functions (gaussian, laplace of gaussian, find local peaks) already support n-dimensions
removed assert_nD checks and altered output format

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

